### PR TITLE
Introduce minimum supported Rust version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,17 @@ jobs:
       with:
         submodules: true
     - run: cargo test
+  msrv-cargo-build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Get minimum supported Rust version
+      run: echo "::set-output name=msrv::$(grep '^rust-version = ' Cargo.toml | grep -o '[0-9.]\+')"
+      id: get_msrv
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ steps.get_msrv.outputs.msrv }}
+    - run: cargo +${{ steps.get_msrv.outputs.msrv }} build --all-targets
   audit-check:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-—
+- Minimum supported Rust version (MSRV) is introduced, we support build with Rust toolchain 1.59+
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "geo302"
 version = "0.1.3"
 edition = "2021"
+rust-version = "1.59"
 description = "A simple geoIP-based redirect proxy"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
We need 1.59 for `Cargo.toml` support of stripping